### PR TITLE
Update GitHub pages workflow to include explicit permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write # Required for deploying pages
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Our organization recently updated the security model for our GitHub actions workflows to require that all repository Github workflows define jobs with explicit permissions (no assumed defaults).

This pull request defines the required permissions for deploying to GitHub pages and should fix the latest failure in the [`GitHub Pages`](https://github.com/useshortcut/shortcut-client-js/actions/workflows/gh-pages.yml) workflow when merged to main.

