### PR TITLE
Update GitHub pages workflow to include `contents: write`

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # Required for deploying pages
       pages: write # Required for deploying pages
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The **peaceiris/actions-gh-pages** GitHub action requires `contents: write` permission to successfully deploy. 

This PR updates the permissions accordingly.

### Testing
- [x] Tested by updating the GitHub workflow to run on this branch and confirmed the GitHub workflow successfully deployed. 
- [x] Ensure reverting local PR deploy workflow