### PR TITLE
chore: [sc-285680] pin github actions with SHA

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,10 +12,10 @@ jobs:
       contents: write # Required for deploying pages
       pages: write # Required for deploying pages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 'lts/*'
           cache: 'yarn'
@@ -25,7 +25,7 @@ jobs:
       - run: yarn build:docs
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
Added explicit versions to our github actions to mitigate supply-chain attacks as recommended in
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions, also updated the actions to their latest version.

Story link: https://app.shortcut.com/internal/story/285680/security-explicit-github-actions-versions-for-shortcut-client-js