### PR TITLE
Prevent double headers in `typedoc`

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "headings": {
+    "readme": false
+  }
+}


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1664" alt="Screenshot 2025-06-06 at 3 02 17 PM" src="https://github.com/user-attachments/assets/0de914cb-bf5d-4c93-b7c7-ec2302b4484c" /> | <img width="1776" alt="Screenshot 2025-06-06 at 3 02 03 PM" src="https://github.com/user-attachments/assets/56df43b7-f79f-47ed-aebb-04ac47ab1ec0" /> |