### PR TITLE
Sync schema for Docs API additions

### DIFF
--- a/schema/shortcut.swagger.json
+++ b/schema/shortcut.swagger.json
@@ -409,6 +409,26 @@
         "text"
       ]
     },
+    "CreateDoc": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "maxLength": 256,
+          "minLength": 1,
+          "description": "The title for the new document",
+          "type": "string"
+        },
+        "content": {
+          "description": "The content for the new document",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "content"
+      ]
+    },
     "CreateEntityTemplate": {
       "description": "Request parameters for creating an entirely new entity template.",
       "type": "object",
@@ -1538,6 +1558,12 @@
           "description": "This field can be set to another unique ID. In the case that the Story has been imported from another tool, the ID in the other tool can be indicated here.",
           "type": "string"
         },
+        "parent_story_id": {
+          "description": "The id of the parent story to associate with this story.",
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true
+        },
         "estimate": {
           "description": "The numeric point estimate of the story. Can also be null, which means unestimated.",
           "type": "integer",
@@ -1866,6 +1892,12 @@
           "maxLength": 1024,
           "description": "This field can be set to another unique ID. In the case that the Story has been imported from another tool, the ID in the other tool can be indicated here.",
           "type": "string"
+        },
+        "parent_story_id": {
+          "description": "The id of the parent story to associate with this story.",
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true
         },
         "estimate": {
           "description": "The numeric point estimate of the story. Can also be null, which means unestimated.",
@@ -2226,6 +2258,44 @@
       "additionalProperties": false,
       "required": [
         "story_ids"
+      ]
+    },
+    "DisabledFeatureError": {
+      "type": "object",
+      "properties": {
+        "feature_tag": {
+          "description": "The feature that is disabled",
+          "type": "string"
+        },
+        "message": {
+          "description": "The message explaining the error",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "feature_tag",
+        "message"
+      ]
+    },
+    "DocSlim": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The public id of the Doc",
+          "type": "string",
+          "format": "uuid"
+        },
+        "title": {
+          "description": "The Docs Title",
+          "type": "string",
+          "x-nullable": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "title"
       ]
     },
     "EntityTemplate": {
@@ -6450,6 +6520,9 @@
         },
         "workspace2": {
           "$ref": "#/definitions/BasicWorkspaceInfo"
+        },
+        "organization2": {
+          "$ref": "#/definitions/MemberInfoOrganization2"
         }
       },
       "additionalProperties": false,
@@ -6459,7 +6532,21 @@
         "mention_name",
         "name",
         "role",
-        "workspace2"
+        "workspace2",
+        "organization2"
+      ]
+    },
+    "MemberInfoOrganization2": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
       ]
     },
     "Milestone": {
@@ -11630,6 +11717,78 @@
         },
         "operationId": "deleteCustomField",
         "summary": "Delete Custom Field"
+      }
+    },
+    "/api/v3/documents": {
+      "get": {
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DocSlim"
+              }
+            },
+            "description": "Resource"
+          },
+          "400": {
+            "description": "Schema mismatch"
+          },
+          "403": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DisabledFeatureError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist"
+          },
+          "422": {
+            "description": "Unprocessable"
+          }
+        },
+        "operationId": "listDocs",
+        "description": "List Docs returns a list of Doc that the current user can read.",
+        "summary": "List Docs"
+      },
+      "post": {
+        "parameters": [
+          {
+            "in": "body",
+            "name": "CreateDoc",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateDoc"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "schema": {
+              "$ref": "#/definitions/DocSlim"
+            },
+            "description": "Resource"
+          },
+          "400": {
+            "description": "Schema mismatch"
+          },
+          "403": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DisabledFeatureError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist"
+          },
+          "422": {
+            "description": "Unprocessable"
+          }
+        },
+        "operationId": "createDoc",
+        "description": "Creates a new Doc.",
+        "summary": "Create Doc"
       }
     },
     "/api/v3/entity-templates": {

--- a/src/generated/Api.ts
+++ b/src/generated/Api.ts
@@ -14,6 +14,7 @@ import type {
   Category,
   CreateCategory,
   CreateCommentComment,
+  CreateDoc,
   CreateEntityTemplate,
   CreateEpic,
   CreateEpicComment,
@@ -36,6 +37,8 @@ import type {
   CustomField,
   DataConflictError,
   DeleteStories,
+  DisabledFeatureError,
+  DocSlim,
   EntityTemplate,
   Epic,
   EpicPaginatedResults,
@@ -301,6 +304,40 @@ export class Api<
       path: `/api/v3/custom-fields/${customFieldPublicId}`,
       method: "DELETE",
       secure: true,
+      ...params,
+    });
+  /**
+   * @description List Docs returns a list of Doc that the current user can read.
+   *
+   * @name ListDocs
+   * @summary List Docs
+   * @request GET:/api/v3/documents
+   * @secure
+   */
+  listDocs = (params: RequestParams = {}) =>
+    this.request<DocSlim[], void | DisabledFeatureError>({
+      path: `/api/v3/documents`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Creates a new Doc.
+   *
+   * @name CreateDoc
+   * @summary Create Doc
+   * @request POST:/api/v3/documents
+   * @secure
+   */
+  createDoc = (CreateDoc: CreateDoc, params: RequestParams = {}) =>
+    this.request<DocSlim, void | DisabledFeatureError>({
+      path: `/api/v3/documents`,
+      method: "POST",
+      body: CreateDoc,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
       ...params,
     });
   /**

--- a/src/generated/data-contracts.ts
+++ b/src/generated/data-contracts.ts
@@ -240,6 +240,17 @@ export interface CreateCommentComment {
   external_id?: string;
 }
 
+export interface CreateDoc {
+  /**
+   * The title for the new document
+   * @minLength 1
+   * @maxLength 256
+   */
+  title: string;
+  /** The content for the new document */
+  content: string;
+}
+
 /** Request parameters for creating an entirely new entity template. */
 export interface CreateEntityTemplate {
   /**
@@ -962,6 +973,11 @@ export interface CreateStoryFromTemplateParams {
    */
   external_id?: string;
   /**
+   * The id of the parent story to associate with this story.
+   * @format int64
+   */
+  parent_story_id?: number | null;
+  /**
    * The numeric point estimate of the story. Can also be null, which means unestimated.
    * @format int64
    */
@@ -1152,6 +1168,11 @@ export interface CreateStoryParams {
    * @maxLength 1024
    */
   external_id?: string;
+  /**
+   * The id of the parent story to associate with this story.
+   * @format int64
+   */
+  parent_story_id?: number | null;
   /**
    * The numeric point estimate of the story. Can also be null, which means unestimated.
    * @format int64
@@ -1363,6 +1384,23 @@ export interface DeleteStories {
    * @uniqueItems true
    */
   story_ids: number[];
+}
+
+export interface DisabledFeatureError {
+  /** The feature that is disabled */
+  feature_tag: string;
+  /** The message explaining the error */
+  message: string;
+}
+
+export interface DocSlim {
+  /**
+   * The public id of the Doc
+   * @format uuid
+   */
+  id: string;
+  /** The Docs Title */
+  title?: string | null;
 }
 
 /** An entity template can be used to prefill various fields when creating new stories. */
@@ -3467,6 +3505,12 @@ export interface MemberInfo {
   name: string;
   role: string;
   workspace2: BasicWorkspaceInfo;
+  organization2: MemberInfoOrganization2;
+}
+
+export interface MemberInfoOrganization2 {
+  /** @format uuid */
+  id: string;
 }
 
 /** (Deprecated) A Milestone is a collection of Epics that represent a release or some other large initiative that you are working on. Milestones have become Objectives, so you should use Objective-related API resources instead of Milestone ones. */


### PR DESCRIPTION
Sync our Swagger schema to regenerate the client with Docs API additions: https://developer.shortcut.com/api/rest/v3#Documents.