### PR TITLE
Disable experimental strip types for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "yarn build:client && yarn build:add-typedoc-comments && tsdown",
+    "build": "yarn build:client && yarn build:add-typedoc-comments && NODE_OPTIONS=\"--no-experimental-strip-types\" tsdown",
     "build:add-typedoc-comments": "npx jscodeshift -t scripts/add-typedoc-comments.ts --extensions=ts --parser=ts src/generated/**",
     "build:client": "swagger-typescript-api generate --path ./schema/shortcut.swagger.json --output ./src/generated --clean-output --axios --modular --templates ./templates",
     "build:docs": "typedoc ./src --exclude 'src/__tests__/**'",


### PR DESCRIPTION
There is currently an issue with Node 22.18.0 that affects `tsdown` and how we load the configuration file, `tsdown.config.ts`. This is currently a CommonJS package by default, but it also supports ESM I don't want to refactor this at this stage to ensure backward compatibility, so I opted to disable this experimental feature (types stripping) that made it the default in 22.18.0 (versus 22.17.1). It explains why the CI was green two weeks ago, but it suddenly fails without any changes to the repository.