### PR TITLE
Use a non-pinned version of `axios`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ]
   },
   "dependencies": {
-    "axios": "1.15.0"
+    "axios": "^1.15.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,10 +1527,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+axios@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
+  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"


### PR DESCRIPTION
Let's use a non-pinned version of `axios`.

Using a pinned version prevents consumers from updating to a later version, and it forces us to release new versions when there are active CVEs. We relied on a pinned version because `axios` ended up compromised, but this is now preventing people from using safety fixes. Instead of relying on a pinned version, we expect consumers to leverage a lockfile combined with a minimum release age strategy:

- Yarn: [`npmMinimalAgeGate`](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate)
- pnpm: [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage)
- Bun: [`minimumReleaseAge`](https://bun.com/docs/pm/cli/install#minimum-release-age)