### PR TITLE
chore(CVE): fix CVEs related to js-yaml

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2805,25 +2805,25 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.14.0":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Details

Fixes the following CVEs:

- CVE-2026-53550 / https://github.com/advisories/GHSA-h67p-54hq-rp68
- CVE-2026-59869 / https://github.com/advisories/GHSA-52cp-r559-cp3m

Affected versions:

- CVE-2026-53550: `<3.15.0` and `>=4.0.0 <=4.1.1`
- CVE-2026-59869: `>=3.0.0 <3.15.0` and `>=4.0.0 <4.3.0`

First versions patched against both advisories are `3.15.0` and `4.3.0`.

```sh
yarn info js-yaml --all --recursive
├─ js-yaml@npm:3.15.0
└─ js-yaml@npm:4.1.1
```

Two versions were installed before the fix. Version `3.15.0` was already safe, while `4.1.1` was vulnerable to both advisories.

```sh
yarn why js-yaml --recursive
@shortcut/client@workspace:.
├─ swagger-cli@npm:4.0.4 -> js-yaml@npm:3.15.0 (via npm:^3.14.0)
├─ swagger-cli@npm:4.0.4 -> js-yaml@npm:4.1.1 (via npm:^4.1.0)
└─ swagger-typescript-api@npm:13.12.2 -> js-yaml@npm:4.1.1 (via npm:^4.1.0)
```

`js-yaml` is transitive. The relevant consumers request `^4.1.0`, which permits the patched `4.3.x` release without parent updates or an override.

```sh
yarn up js-yaml --recursive
➤ YN0085: │ + js-yaml@npm:3.15.1, js-yaml@npm:4.3.1
➤ YN0085: │ - js-yaml@npm:3.15.0, js-yaml@npm:4.1.1
```

This is a lockfile-only re-resolution. No manifests, parent dependencies, or `resolutions` entries were changed.

## Testing

### Version comparison

Before the fix:

- `3.15.0`, safe
- `4.1.1`, vulnerable

After the fix:

- `3.15.1`, safe
- `4.3.1`, safe

```sh
yarn info js-yaml --all --recursive
├─ js-yaml@npm:3.15.1
└─ js-yaml@npm:4.3.1
```

```sh
yarn npm audit --all --recursive
```

No `js-yaml` advisories remain. The audit continues to report unrelated existing advisories for `ajv`, `brace-expansion`, `yaml`, and deprecated `@apidevtools/swagger-cli`.

```sh
yarn install --immutable
➤ YN0000: · Done with warnings
```

```sh
yarn test --run
Test Files  3 passed (3)
Tests       6 passed (6)
```

```sh
yarn lint
Found 0 warnings and 0 errors.
```

```sh
yarn format:check
All matched files use correct format.
```

```sh
yarn build
```

Build completed successfully with existing code-generator warnings.

```sh
yarn validate:examples
```

```sh
git diff --check
```