### PR TITLE
chore[sc-319115]-Update 'js-yaml' to patched versions to resolve CVEs.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,13 +2817,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Details:

Fixes the vulnerable `js-yaml` versions associated with CVE-2026-53889, CVE-2026-53550, and GHSA-5p4m-2wfm-xmqj.

- Re-resolves `js-yaml` 3.x from `3.15.0` to patched `3.15.1`
- Re-resolves `js-yaml` 4.x from `4.1.1` to patched `4.3.1`
- Keeps the change scoped to `yarn.lock`
- Dependabot alerts: [#125](https://github.com/useshortcut/shortcut-client-js/security/dependabot/125), [#134](https://github.com/useshortcut/shortcut-client-js/security/dependabot/134), [#163](https://github.com/useshortcut/shortcut-client-js/security/dependabot/163), [#164](https://github.com/useshortcut/shortcut-client-js/security/dependabot/164)
- Shortcut story: [sc-319115](https://app.shortcut.com/internal/story/319115)

### Dependency Graph:

`yarn info js-yaml --all --recursive` output - before:

```text
├─ js-yaml@npm:3.15.0
│  ├─ Version: 3.15.0
│  │ 
│  ├─ Exported Binaries
│  │  └─ js-yaml
│  │ 
│  └─ Dependencies
│     ├─ argparse@npm:^1.0.7 → npm:1.0.10
│     └─ esprima@npm:^4.0.0 → npm:4.0.1
│
└─ js-yaml@npm:4.1.1
   ├─ Version: 4.1.1
   │ 
   ├─ Exported Binaries
   │  └─ js-yaml
   │ 
   └─ Dependencies
      └─ argparse@npm:^2.0.1 → npm:2.0.1
```

`yarn info js-yaml --all --recursive` output - after:

```text
├─ js-yaml@npm:3.15.1
│  ├─ Version: 3.15.1
│  │ 
│  ├─ Exported Binaries
│  │  └─ js-yaml
│  │ 
│  └─ Dependencies
│     ├─ argparse@npm:^1.0.7 → npm:1.0.10
│     └─ esprima@npm:^4.0.0 → npm:4.0.1
│
└─ js-yaml@npm:4.3.1
   ├─ Version: 4.3.1
   │ 
   ├─ Exported Binaries
   │  └─ js-yaml
   │ 
   └─ Dependencies
      └─ argparse@npm:^2.0.1 → npm:2.0.1
```

`yarn why js-yaml --recursive` output - before:

```text
└─ @shortcut/client@workspace:.
   ├─ swagger-cli@npm:4.0.4 (via npm:4.0.4)
   │  └─ @apidevtools/swagger-cli@npm:4.0.4 (via npm:4.0.4)
   │     ├─ @apidevtools/swagger-parser@npm:10.1.1 [25d5c] (via npm:^10.0.1 [25d5c])
   │     │  └─ @apidevtools/json-schema-ref-parser@npm:11.7.2 (via npm:11.7.2)
   │     │     └─ js-yaml@npm:4.1.1 (via npm:^4.1.0)
   │     └─ js-yaml@npm:3.15.0 (via npm:^3.14.0)
   └─ swagger-typescript-api@npm:13.12.2 (via npm:13.12.2)
      └─ @apidevtools/swagger-parser@npm:12.1.0 [49981] (via npm:12.1.0 [49981])
         └─ @apidevtools/json-schema-ref-parser@npm:14.0.1 (via npm:14.0.1)
            └─ js-yaml@npm:4.1.1 (via npm:^4.1.0)
```

`yarn why js-yaml --recursive` output - after:

```text
└─ @shortcut/client@workspace:.
   ├─ swagger-cli@npm:4.0.4 (via npm:4.0.4)
   │  └─ @apidevtools/swagger-cli@npm:4.0.4 (via npm:4.0.4)
   │     ├─ @apidevtools/swagger-parser@npm:10.1.1 [25d5c] (via npm:^10.0.1 [25d5c])
   │     │  └─ @apidevtools/json-schema-ref-parser@npm:11.7.2 (via npm:11.7.2)
   │     │     └─ js-yaml@npm:4.3.1 (via npm:^4.1.0)
   │     └─ js-yaml@npm:3.15.1 (via npm:^3.14.0)
   └─ swagger-typescript-api@npm:13.12.2 (via npm:13.12.2)
      └─ @apidevtools/swagger-parser@npm:12.1.0 [49981] (via npm:12.1.0 [49981])
         └─ @apidevtools/json-schema-ref-parser@npm:14.0.1 (via npm:14.0.1)
            └─ js-yaml@npm:4.3.1 (via npm:^4.1.0)
```