### PR TITLE
chore[sc-319148]-Update 'dompurify' to patched version to resolve CVE.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,14 +2242,14 @@ __metadata:
   linkType: hard
 
 "dompurify@npm:^3.4.1":
-  version: 3.4.12
-  resolution: "dompurify@npm:3.4.12"
+  version: 3.4.13
+  resolution: "dompurify@npm:3.4.13"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+  checksum: 10c0/9c2a1a71e1a1d8b77953db7a39ffc935ef4ed4f10fe40770232128c2cbfd4c3dc677d3d7bae51eb24cc52d9ff3548612dc540ecb4343e89b26e809d2be2e0cfe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Details:

Fixes the vulnerable dompurify version associated with GHSA-55q2-jh2-7xh7 (https://github.com/advisories/GHSA-55q2-jh2-7xh7).
- Re-resolves dompurify from 3.4.12 to patched 3.4.13
- Addresses a moderate-severity XSS vulnerability affecting IN_PLACE sanitization
- Keeps the change scoped to yarn.lock
- Dependabot alert: (https://github.com/useshortcut/shortcut-client-js/security/dependabot/161)
- Shortcut story: sc-319148 (https://app.shortcut.com/internal/story/319148)

### Dependency Graph:

`yarn info dompurify --all --recursive output` - before:

```text
└─ dompurify@npm:3.4.12
   ├─ Version: 3.4.12
   │ 
   └─ Dependencies
      └─ @types/trusted-types@npm:^2.0.7 → npm:2.0.7
```

`yarn info dompurify --all --recursive` output - after:

```text
└─ dompurify@npm:3.4.13
   ├─ Version: 3.4.13
   │ 
   └─ Dependencies
      └─ @types/trusted-types@npm:^2.0.7 → npm:2.0.7
```

`yarn why dompurify --recursive` output - before:

```text
└─ @shortcut/client@workspace:.
   └─ swagger-typescript-api@npm:13.12.2 (via npm:13.12.2)
      └─ yummies@npm:7.19.4 [49981] (via npm:7.19.4 [49981])
         └─ dompurify@npm:3.4.12 (via npm:^3.4.1)
```

`yarn why dompurify --recursive` output - after:

```text
└─ @shortcut/client@workspace:.
   └─ swagger-typescript-api@npm:13.12.2 (via npm:13.12.2)
      └─ yummies@npm:7.19.4 [49981] (via npm:7.19.4 [49981])
         └─ dompurify@npm:3.4.13 (via npm:^3.4.1)
```